### PR TITLE
CMake: make picosystem a package for out of tree projects

### DIFF
--- a/examples/snake/CMakeLists.txt
+++ b/examples/snake/CMakeLists.txt
@@ -1,9 +1,23 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Pull in PICO SDK (must be before project)
+include(../../pico_sdk_import.cmake)
+
+project(snake C CXX ASM)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# Initialize the SDK
+pico_sdk_init()
+
 add_definitions(-DPIXEL_DOUBLE -DNO_STARTUP_LOGO)
 
 add_executable(
   snake
   snake.cpp
 )
+
+find_package(PICOSYSTEM REQUIRED)
 
 # Pull in pico libraries that we need
 target_link_libraries(snake picosystem)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,18 +1,1 @@
-add_library(picosystem INTERFACE)
-
-pico_generate_pio_header(picosystem ${CMAKE_CURRENT_LIST_DIR}/screen.pio)
-pico_generate_pio_header(picosystem ${CMAKE_CURRENT_LIST_DIR}/screen_double.pio)
-
-target_sources(picosystem INTERFACE
-  ${CMAKE_CURRENT_LIST_DIR}/picosystem.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/blend.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/state.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/primitives.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/utility.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/hardware.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/assets.cpp
-)
-
-target_include_directories(picosystem INTERFACE ${CMAKE_CURRENT_LIST_DIR})
-
-target_link_libraries(picosystem INTERFACE pico_stdlib hardware_pio hardware_spi hardware_pwm hardware_dma hardware_irq hardware_adc hardware_interp)
+include(picosystem)

--- a/libraries/picosystem.cmake
+++ b/libraries/picosystem.cmake
@@ -1,0 +1,18 @@
+add_library(picosystem INTERFACE)
+
+pico_generate_pio_header(picosystem ${CMAKE_CURRENT_LIST_DIR}/screen.pio)
+pico_generate_pio_header(picosystem ${CMAKE_CURRENT_LIST_DIR}/screen_double.pio)
+
+target_sources(picosystem INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/picosystem.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/blend.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/state.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/primitives.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/utility.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/hardware.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/assets.cpp
+)
+
+target_include_directories(picosystem INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+target_link_libraries(picosystem INTERFACE pico_stdlib hardware_pio hardware_spi hardware_pwm hardware_dma hardware_irq hardware_adc hardware_interp)

--- a/picosystem-config.cmake
+++ b/picosystem-config.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/libraries/picosystem.cmake)


### PR DESCRIPTION
Add picosystem-config.cmake to the project root so that it can be used with `find_package(PICOSYSTEM)` and `-DPICOSYSTEM_DIR`

Update snake to use find_package. We should probably make an out-of-tree boilerplate project for this... maybe?

An out-of-tree project needs to include `pico_sdk_import.cmake` and the CMakeLists.txt should include standard Pico SDK setup like so:

```cmake
cmake_minimum_required(VERSION 3.12)

# Pull in PICO SDK (must be before project)
include(pico_sdk_import.cmake)

project(snake C CXX ASM)
set(CMAKE_C_STANDARD 11)
set(CMAKE_CXX_STANDARD 17)

# Initialize the SDK
pico_sdk_init()

add_definitions(-DPIXEL_DOUBLE -DNO_STARTUP_LOGO)

add_executable(
  snake
  snake.cpp
)

find_package(PICOSYSTEM REQUIRED)

# Pull in pico libraries that we need
target_link_libraries(snake picosystem)

# create map/bin/hex file etc.
pico_add_extra_outputs(snake)
```

This can then be configured with:

```
cmake .. -DPICO_SDK_PATH=~/pico-sdk -DPICOSYSTEM_DIR=~/picosystem
```

