### PR TITLE
More improvements to PicoSystem out-of-tree targets + bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,4 @@ set(CMAKE_CXX_STANDARD 17)
 # Initialize the SDK
 pico_sdk_init()
 
-add_subdirectory(libraries)
 add_subdirectory(examples)

--- a/examples/snake/CMakeLists.txt
+++ b/examples/snake/CMakeLists.txt
@@ -7,20 +7,12 @@ project(snake C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
-# Initialize the SDK
-pico_sdk_init()
+find_package(PICOSYSTEM REQUIRED)
 
-add_definitions(-DPIXEL_DOUBLE -DNO_STARTUP_LOGO)
-
-add_executable(
+picosystem_executable(
   snake
   snake.cpp
 )
 
-find_package(PICOSYSTEM REQUIRED)
-
-# Pull in pico libraries that we need
-target_link_libraries(snake picosystem)
-
-# create map/bin/hex file etc.
-pico_add_extra_outputs(snake)
+pixel_double(snake)
+disable_startup_logo(snake)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,1 +1,1 @@
-include(picosystem)
+include(picosystem.cmake)

--- a/libraries/picosystem.cmake
+++ b/libraries/picosystem.cmake
@@ -1,3 +1,6 @@
+# Initialize the Pico SDK
+pico_sdk_init()
+
 add_library(picosystem INTERFACE)
 
 pico_generate_pio_header(picosystem ${CMAKE_CURRENT_LIST_DIR}/screen.pio)
@@ -16,3 +19,25 @@ target_sources(picosystem INTERFACE
 target_include_directories(picosystem INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 target_link_libraries(picosystem INTERFACE pico_stdlib hardware_pio hardware_spi hardware_pwm hardware_dma hardware_irq hardware_adc hardware_interp)
+
+function(picosystem_executable NAME SOURCES)
+  add_executable(
+    ${NAME}
+    ${SOURCES}
+    ${ARGN}
+  )
+
+  # Pull in pico libraries that we need
+  target_link_libraries(${NAME} picosystem)
+
+  # create map/bin/hex file etc.
+  pico_add_extra_outputs(${NAME})
+endfunction()
+
+function(pixel_double NAME)
+  target_compile_options(${NAME} PRIVATE -DPIXEL_DOUBLE)
+endfunction()
+
+function(disable_startup_logo NAME)
+  target_compile_options(${NAME} PRIVATE -DNO_STARTUP_LOGO)
+endfunction()


### PR DESCRIPTION
Moves basic set up of an executable target and inclusion of the PicoSystem library into a new function: picosystem_executable

Wraps the PIXEL_DOUBLE and NO_STARTUP_LOGO compiler flags in friendly functions:
* pixel_double(<target>)
* disable_startup_logo(<target>)

Fixes building from the project root.
