### PR TITLE
Add wrappers for other build options & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ D-pad and buttons picked out by our most particular arcade enthusiasts. There's
 also a piezo speaker for discreet retro bleeps and chirps and a rechargeable
 LiPo battery so you can take your homebrew games on the bus.
 
+- [PicoSystem libraries and examples](#picosystem-libraries-and-examples)
+  - [MicroPython](#micropython)
+  - [C++ API](#c-api)
+    - [Getting started](#getting-started)
+    - [Booting PicoSystem into DFU mode](#booting-picosystem-into-dfu-mode)
+    - [Example CMakeLists.txt](#example-cmakeliststxt)
+    - [Build options](#build-options)
+    - [Compiler flags](#compiler-flags)
+  - [General Information](#general-information)
+    - [Hardware](#hardware)
+    - [Graphics modes](#graphics-modes)
+
 ## MicroPython
 
 We also provide a custom MicroPython image for PicoSystem which
@@ -27,7 +39,7 @@ hardware and help with drawing, audio, and user input.
 Once you're comfortable with building your project for PicoSystem you may find
 our [PicoSystem C++ API Cheatsheet](https://learn.pimoroni.com/article/picosystem-api-cheatsheet) a useful reference to keep open.
 
-## Getting started
+### Getting started
 
 *First things first!* You must install
 [Raspberry Pi's Pico SDK](https://github.com/raspberrypi/pico-sdk) following the
@@ -58,7 +70,7 @@ You will now have the examples built in `~/picosystem/build/examples` for exampl
 `~/picosystem/build/examples/snake/snake.uf2`. This file can be dropped onto your
 PicoSystem when in [DFU mode](#booting-picosystem-into-dfu-mode).
 
-## Booting PicoSystem into DFU mode
+### Booting PicoSystem into DFU mode
 
 Hold down the `X` action button and toggle the power. PicoSystem will boot into
 DFU mode and appear as a disk on your computer.
@@ -66,11 +78,52 @@ DFU mode and appear as a disk on your computer.
 Simply drag a `.uf2` file onto the PicoSystem disk and it will be uploaded and
 launch immediately.
 
-## Build flags
+### Example CMakeLists.txt
 
-There are a few flags you can pass to the compiler when building your project
-to change the behaviour of PicoSystem. These can be set by adding
-`add_definitions(-DFLAGNAME)` to your `CMakeLists.txt`.
+If you're building your own out-of-tree project you'll need to include and import the `pico_sdk_import.cmake` file,
+as per regular Pico SDK setup instructions.
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+
+# Pull in PICO SDK (must be before project)
+include(../../pico_sdk_import.cmake)
+
+project(snake C CXX ASM)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# Find the PicoSystem SDK
+find_package(PICOSYSTEM REQUIRED)
+
+# Set up your project and sources
+picosystem_executable(
+  my_project
+  my_source_file.cpp
+)
+
+# Example build options
+pixel_double(my_project)
+disable_startup_logo(my_project)
+```
+
+### Build options
+
+There are a few options you can set in your project to change the behaviour of PicoSystem.
+
+These can be set by adding one of the following lines in your `CMakeLists.txt`:
+
+- `pixel_double(NAME)`: set resolution  to 120x120 for a retro chunky pixel aesthetic (and significant RAM saving)
+- `no_spritesheet(NAME)`: do not include the default sprite sheet (saves 32kB of RAM)
+- `no_font(NAME)`: do not include the default font (saves 1kB)
+- `disable_startup_logo(NAME)`: disables the PicoSystem statrtup logo animation
+- `no_overclock(NAME)`: disables overclocking of the RP2040 (by default we set it to 250MHz)
+
+In all cases `NAME` should be the name you supplied to `picosystem_executable`.
+
+### Compiler flags
+
+If you need them, the build options are also available as compiler flags:
 
 - `-DPIXEL_DOUBLE`: set resolution to 120x120 for a retro chunky pixel aesthetic
 (saves 84kB of RAM)
@@ -81,7 +134,9 @@ RAM)
 - `-DNO_OVERCLOCK`: disables overclocking of the RP2040 (by default we set it
 to 250MHz)
 
-## Hardware
+## General Information
+
+### Hardware
 
 - Powered by RP2040 (Dual Arm Cortex M0+ with 264kB of SRAM)
 - 16MB of QSPI flash supporting XiP
@@ -93,7 +148,7 @@ to 250MHz)
 - RGB LED
 - Programmable and rechargeable via USB-C (cable not included)
 
-## Graphics modes
+### Graphics modes
 
 PicoSystem supports two graphics modes.
 

--- a/libraries/picosystem.cmake
+++ b/libraries/picosystem.cmake
@@ -41,3 +41,15 @@ endfunction()
 function(disable_startup_logo NAME)
   target_compile_options(${NAME} PRIVATE -DNO_STARTUP_LOGO)
 endfunction()
+
+function(no_font NAME)
+  target_compile_options(${NAME} PRIVATE -DNO_FONT)
+endfunction()
+
+function(no_spritesheet NAME)
+  target_compile_options(${NAME} PRIVATE -DNO_SPRITESHEET)
+endfunction()
+
+function(no_overclock NAME)
+  target_compile_options(${NAME} PRIVATE -DNO_OVERCLOCK)
+endfunction()


### PR DESCRIPTION
Adds convenience wrappers for the rest of the build flags. These aren't strictly necessary but they hurt my eyes less.

Also updates the README with a table of contents, example CMakeLists and documentation of the newly added options.