### PR TITLE
CMake: Remove find_package for examples, fix template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,7 @@ set(CMAKE_CXX_STANDARD 17)
 # Initialize the SDK
 pico_sdk_init()
 
-# Would find_package kindly search PATHS
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
-
-# Find the PicoSystem library
-find_package(PICOSYSTEM CONFIG REQUIRED PATHS ..)
+# Include the PicoSystem library
+include(${CMAKE_CURRENT_LIST_DIR}/libraries/picosystem.cmake REQUIRED)
 
 add_subdirectory(examples)

--- a/template/CMakeLists.txt
+++ b/template/CMakeLists.txt
@@ -28,11 +28,8 @@ set(CMAKE_CXX_STANDARD 17)
 # Initialize the SDK
 pico_sdk_init()
 
-# Would find_package kindly search PATHS
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
-
 # Find the PicoSystem library
-find_package(PICOSYSTEM CONFIG REQUIRED PATHS .. ../picosystem)
+include(picosystem_sdk_import.cmake)
 
 # Create the output target
 picosystem_executable(

--- a/template/picosystem_sdk_import.cmake
+++ b/template/picosystem_sdk_import.cmake
@@ -1,0 +1,15 @@
+if(NOT PICOSYSTEM_DIR)
+  list(APPEND PICOSYSTEM_SDK_SEARCH_PATHS
+  ${CMAKE_CURRENT_LIST_DIR}/../picosystem
+    ${CMAKE_CURRENT_LIST_DIR}/../
+  )
+  foreach(SEARCH_PATH ${PICOSYSTEM_SDK_SEARCH_PATHS})
+    get_filename_component(SEARCH_PATH ${SEARCH_PATH} ABSOLUTE)
+    if(EXISTS ${SEARCH_PATH}/picosystem-config.cmake)
+      message("PICOSYSTEM_DIR is ${SEARCH_PATH}")
+      set(PICOSYSTEM_DIR ${SEARCH_PATH})
+      break()
+    endif()
+  endforeach()
+endif()
+find_package(PICOSYSTEM CONFIG REQUIRED)


### PR DESCRIPTION
Template now uses picossytem_sdk_import.cmake which searches a couple of adjacent paths.

Full build simply imports the package, no nonsense!