### PR TITLE
CMake: Add picosystem_asset for packing .16bpp into .o

### DIFF
--- a/libraries/picosystem.cmake
+++ b/libraries/picosystem.cmake
@@ -34,6 +34,21 @@ function(picosystem_executable NAME SOURCES)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.uf2 DESTINATION .)
 endfunction()
 
+function(picosystem_asset NAME PATH)
+  get_filename_component(PATH ${PATH} ABSOLUTE)
+  get_filename_component(ASSET ${PATH} NAME)
+  get_filename_component(PATH ${PATH} DIRECTORY)
+  set(OBJNAME ${ASSET}.o)
+  message("Building ${OBJNAME}")
+  add_custom_command(OUTPUT ${OBJNAME}
+    WORKING_DIRECTORY ${PATH}
+    COMMAND ${CMAKE_LINKER} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${OBJNAME} ${ASSET})
+  # TODO figure out how to make static resources work
+    ## COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/${OBJNAME} ${CMAKE_CURRENT_BINARY_DIR}/${OBJNAME})
+
+  target_sources(${NAME} PRIVATE ${OBJNAME})
+endfunction()
+
 function(pixel_double NAME)
   target_compile_options(${NAME} PRIVATE -DPIXEL_DOUBLE)
 endfunction()

--- a/template/CMakeLists.txt
+++ b/template/CMakeLists.txt
@@ -35,6 +35,9 @@ picosystem_executable(
   ${PROJECT_SOURCES}
 )
 
+# Link the platformer spritesheet
+picosystem_asset(${PROJECT_NAME} ../assets/s4m_ur4i-platformer.16bpp)
+
 # --- End Of Boilerplate ---
 
 # Set your build options here

--- a/template/main.cpp
+++ b/template/main.cpp
@@ -2,11 +2,21 @@
 
 using namespace picosystem;
 
+extern char _binary_s4m_ur4i_platformer_16bpp_start[];
+buffer_t *platformer = buffer(128, 128, (void *)_binary_s4m_ur4i_platformer_16bpp_start);
+
 void init() {
+    spritesheet(platformer);
 }
 
 void update(uint32_t tick) {
 }
 
 void draw(uint32_t tick) {
+    pen(0, 0, 0);
+    clear();
+    pen(15, 15, 15);
+    text("Hello World", 14, 12);
+    sprite(192, 4, 4);
+    sprite(192 + 16, 4, 12);
 }


### PR DESCRIPTION
Use the linker to convert an asset into an .o file and include it in project sources.

TODO: Fix const resources/.rodata assets

### Example

Add the following to your `CMakeLists.txt`:

```cmake
# Link the platformer spritesheet
picosystem_asset(${PROJECT_NAME} ../assets/s4m_ur4i-platformer.16bpp)
```

And to your main `.cpp`:

```c++
extern char _binary_s4m_ur4i_platformer_16bpp_start[];
buffer_t *platformer = buffer(128, 128, (void *)_binary_s4m_ur4i_platformer_16bpp_start);

void init() {
    spritesheet(platformer);
}
```

:warning: At the moment I can't seem to get this working with constant data, so it will eat 32K of RAM.