### PR TITLE
MicroPython: Include function name in errors. IO in flip()

### DIFF
--- a/micropython/modules/picosystem/buffer.cpp
+++ b/micropython/modules/picosystem/buffer.cpp
@@ -56,7 +56,7 @@ mp_obj_t PicosystemBuffer_make_new(const mp_obj_type_t *type, size_t n_args, siz
     int h = args[ARG_h].u_int;
 
     if(w <= 0 || h <= 0) {
-        mp_raise_ValueError("Buffer: both w and h must be greater than zero");
+        mp_raise_ValueError("Buffer(): both w and h must be greater than zero");
     }
 
     self = m_new_obj_with_finaliser(_PicosystemBuffer_obj_t);

--- a/micropython/modules/picosystem/hardware.cpp
+++ b/micropython/modules/picosystem/hardware.cpp
@@ -31,7 +31,7 @@ mp_obj_t picosystem_pressed(mp_obj_t b_obj) {
             break;
 
         default:
-            mp_raise_ValueError("button not valid.");
+            mp_raise_ValueError("pressed(): invalid button.");
             break;
     }
 
@@ -55,7 +55,7 @@ mp_obj_t picosystem_button(mp_obj_t b_obj) {
             break;
 
         default:
-            mp_raise_ValueError("button not valid.");
+            mp_raise_ValueError("button(): invalid button.");
             break;
     }
 
@@ -72,13 +72,13 @@ mp_obj_t picosystem_led(mp_obj_t r_obj, mp_obj_t g_obj, mp_obj_t b_obj) {
     int b = mp_obj_get_int(b_obj);
 
     if(r < 0 || r > 100) {
-        mp_raise_ValueError("r out of range. Expected 0 to 100");
+        mp_raise_ValueError("led(): r out of range. Expected 0 to 100");
     }
     else if(g < 0 || g > 100) {
-        mp_raise_ValueError("g out of range. Expected 0 to 100");
+        mp_raise_ValueError("led(): g out of range. Expected 0 to 100");
     }
     else if(b < 0 || b > 100) {
-        mp_raise_ValueError("b out of range. Expected 0 to 100");
+        mp_raise_ValueError("led(): b out of range. Expected 0 to 100");
     }
     else {
         led(r, g, b);
@@ -91,7 +91,7 @@ mp_obj_t picosystem_backlight(mp_obj_t b_obj) {
     int b = mp_obj_get_int(b_obj);
 
     if(b < 0 || b > 100) {
-        mp_raise_ValueError("b out of range. Expected 0 to 100");
+        mp_raise_ValueError("led(): b out of range. Expected 0 to 100");
     }
     else {
         backlight(b);

--- a/micropython/modules/picosystem/picosystem.cpp
+++ b/micropython/modules/picosystem/picosystem.cpp
@@ -175,6 +175,9 @@ mp_obj_t picosystem_quit(){
 
 /* flip() - Flip the buffer, use this from the repl! (or, your own main loop?) */
 mp_obj_t picosystem_flip() {
+    _lio = _io;
+    _io = _gpio_get();
+
     while(_is_flipping()) {
         best_effort_wfe_or_timeout(make_timeout_time_us(500));
     }

--- a/micropython/modules/picosystem/primitives.cpp
+++ b/micropython/modules/picosystem/primitives.cpp
@@ -124,11 +124,11 @@ mp_obj_t picosystem_poly(mp_uint_t n_args, const mp_obj_t *args) {
                 tuples = points->items;
             }
             else {
-                mp_raise_ValueError("cannot provide an empty list");
+                mp_raise_ValueError("poly(): cannot provide an empty list");
             }
         }
         else {
-            mp_raise_TypeError("can't convert object to list");
+            mp_raise_TypeError("poly(): can't convert object to list");
         }
     }
 
@@ -139,12 +139,12 @@ mp_obj_t picosystem_poly(mp_uint_t n_args, const mp_obj_t *args) {
         for(size_t i = 0; i < num_tuples; i++) {
             mp_obj_t obj = tuples[i];
             if(!mp_obj_is_type(obj, &mp_type_tuple)) {
-                mp_raise_ValueError("can't convert object to tuple");
+                mp_raise_ValueError("poly(): can't convert object to tuple");
             }
             else {
                 mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR2(obj, mp_obj_tuple_t);
                 if(tuple->len != 2) {
-                    mp_raise_ValueError("tuple must only contain two numbers");
+                    mp_raise_ValueError("poly(): tuple must only contain two numbers");
                 }
                 i2 = i * 2;
                 points[i2] = mp_obj_get_int(tuple->items[0]);
@@ -171,11 +171,11 @@ mp_obj_t picosystem_fpoly(mp_uint_t n_args, const mp_obj_t *args) {
                 tuples = points->items;
             }
             else {
-                mp_raise_ValueError("cannot provide an empty list");
+                mp_raise_ValueError("fpoly(): cannot provide an empty list");
             }
         }
         else {
-            mp_raise_TypeError("can't convert object to list");
+            mp_raise_TypeError("fpoly(): can't convert object to list");
         }
     }
 
@@ -186,12 +186,12 @@ mp_obj_t picosystem_fpoly(mp_uint_t n_args, const mp_obj_t *args) {
         for(size_t i = 0; i < num_tuples; i++) {
             mp_obj_t obj = tuples[i];
             if(!mp_obj_is_type(obj, &mp_type_tuple)) {
-                mp_raise_ValueError("can't convert object to tuple");
+                mp_raise_ValueError("fpoly(): can't convert object to tuple");
             }
             else {
                 mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR2(obj, mp_obj_tuple_t);
                 if(tuple->len != 2) {
-                    mp_raise_ValueError("tuple must only contain two numbers");
+                    mp_raise_ValueError("fpoly(): tuple must only contain two numbers");
                 }
                 i2 = i * 2;
                 points[i2] = mp_obj_get_int(tuple->items[0]);
@@ -215,10 +215,16 @@ mp_obj_t picosystem_blit(mp_uint_t n_args, const mp_obj_t *args) {
         int h = mp_obj_get_int(args[4]);
         int dx = mp_obj_get_int(args[5]);
         int dy = mp_obj_get_int(args[6]);
-        blit(buffer_obj->buffer, x, y, w, h, dx, dy);
+        if(n_args == 9) {
+            int dw = mp_obj_get_int(args[7]);
+            int dh = mp_obj_get_int(args[8]);
+            blit(buffer_obj->buffer, x, y, w, h, dx, dy, dw, dh);
+        } else {
+            blit(buffer_obj->buffer, x, y, w, h, dx, dy);
+        }
     }
     else {
-        mp_raise_TypeError("src is not a valid buffer. Expected a Buffer class");
+        mp_raise_TypeError("blit(): src is not a valid buffer. Expected a Buffer class");
     }
     return mp_const_none;
 }

--- a/micropython/modules/picosystem/text.cpp
+++ b/micropython/modules/picosystem/text.cpp
@@ -34,17 +34,8 @@ mp_obj_t picosystem_text(mp_uint_t n_args, const mp_obj_t *args) {
             text(t);
         }
     }
-    else if(mp_obj_is_float(args[0])) {
-        mp_raise_TypeError("can't convert 'float' object to str implicitly");
-    }
-    else if(mp_obj_is_int(args[0])) {
-        mp_raise_TypeError("can't convert 'int' object to str implicitly");
-    }
-    else if(mp_obj_is_bool(args[0])) {
-        mp_raise_TypeError("can't convert 'bool' object to str implicitly");
-    }
     else {
-        mp_raise_TypeError("can't convert object to str implicitly");
+        mp_raise_TypeError("text(): string required!");
     }
 
     return mp_const_none;
@@ -67,17 +58,8 @@ mp_obj_t picosystem_measure(mp_uint_t n_args, const mp_obj_t *args) {
         tuple[1] = mp_obj_new_int(h);
         return mp_obj_new_tuple(2, tuple);
     }
-    else if(mp_obj_is_float(str_obj)) {
-        mp_raise_TypeError("can't convert 'float' object to str implicitly");
-    }
-    else if(mp_obj_is_int(str_obj)) {
-        mp_raise_TypeError("can't convert 'int' object to str implicitly");
-    }
-    else if(mp_obj_is_bool(str_obj)) {
-        mp_raise_TypeError("can't convert 'bool' object to str implicitly");
-    }
     else {
-        mp_raise_TypeError("can't convert object to str implicitly");
+        mp_raise_TypeError("text(): string required!");
     }
 
     return mp_const_none;

--- a/micropython/modules/picosystem/utility.cpp
+++ b/micropython/modules/picosystem/utility.cpp
@@ -19,19 +19,19 @@ mp_obj_t picosystem_rgb(mp_uint_t n_args, const mp_obj_t *args) {
     int g = mp_obj_get_int(args[1]);
     int b = mp_obj_get_int(args[2]);
     if(r < 0 || r > 15) {
-        mp_raise_ValueError("r out of range. Expected 0 to 15");
+        mp_raise_ValueError("rgb(): r out of range. Expected 0 to 15");
     }
     else if(g < 0 || g > 15) {
-        mp_raise_ValueError("g out of range. Expected 0 to 15");
+        mp_raise_ValueError("rgb(): g out of range. Expected 0 to 15");
     }
     else if(b < 0 || b > 15) {
-        mp_raise_ValueError("b out of range. Expected 0 to 15");
+        mp_raise_ValueError("rgb(): b out of range. Expected 0 to 15");
     }
     else {
         if(n_args == 4) {
             int a = mp_obj_get_int(args[3]);
             if(a < 0 || a > 15) {
-                mp_raise_ValueError("a out of range. Expected 0 to 15");
+                mp_raise_ValueError("rgb(): a out of range. Expected 0 to 15");
             }
             else {
                 return mp_obj_new_int(rgb(r, g, b, a));
@@ -49,19 +49,19 @@ mp_obj_t picosystem_hsv(mp_uint_t n_args, const mp_obj_t *args) {
     float s = mp_obj_get_float(args[1]);
     float v = mp_obj_get_float(args[2]);
     if(h < 0.0f || h > 1.0f) {
-        mp_raise_ValueError("h out of range. Expected 0.0 to 1.0");
+        mp_raise_ValueError("hsv(): h out of range. Expected 0.0 to 1.0");
     }
     else if(s < 0.0f || s > 1.0f) {
-        mp_raise_ValueError("s out of range. Expected 0.0 to 1.0");
+        mp_raise_ValueError("hsv(): s out of range. Expected 0.0 to 1.0");
     }
     else if(v < 0.0f || v > 1.0f) {
-        mp_raise_ValueError("v out of range. Expected 0.0 to 1.0");
+        mp_raise_ValueError("hsv(): v out of range. Expected 0.0 to 1.0");
     }
     else {
         if(n_args == 4) {
             float a = mp_obj_get_float(args[3]);
             if(a < 0.0f || a > 1.0f) {
-                mp_raise_ValueError("v out of range. Expected 0.0 to 1.0");
+                mp_raise_ValueError("hsv(): v out of range. Expected 0.0 to 1.0");
             }
             return mp_obj_new_int(hsv(h, s, v, a));
         }


### PR DESCRIPTION
* Add button reading to flip() for REPL and custom loop use.
* Add the name of each function to the start of any errors for consistency and gentle beginner friendliness.
* Drop all the special cases in text() and just fail fast.