### PR TITLE
Added audio_playing() function

### DIFF
--- a/libraries/audio.cpp
+++ b/libraries/audio.cpp
@@ -23,6 +23,11 @@ namespace picosystem {
     return _ms;
   }
 
+  // Convenience function to tell if the note is still playing
+  bool audio_playing() {
+    return !(_ms > _duration + _voice.release + _voice.reverb);
+  }
+
   uint8_t audio_sample(uint32_t ms) {
     // calculate full duration including release and reverb
     uint32_t full_duration = _duration + _voice.release + _voice.reverb;

--- a/libraries/picosystem.hpp
+++ b/libraries/picosystem.hpp
@@ -171,6 +171,7 @@ namespace picosystem {
                 uint32_t duration = 500, uint32_t volume = 100);
   uint8_t     audio_sample(uint32_t ms);
   uint32_t    audio_position();
+  bool        audio_playing();
 
   // utility
   std::string str(float v, uint8_t precision = 2);


### PR DESCRIPTION
Added a convenience function to be able to easily tell if the current note is still playing; essentially wrapping what the audio example does into the API.