### PR TITLE
SDK: Overvolt from 1.1v to 1.2v

### DIFF
--- a/libraries/hardware.cpp
+++ b/libraries/hardware.cpp
@@ -7,6 +7,7 @@
 #include "hardware/pwm.h"
 #include "hardware/pio.h"
 #include "hardware/irq.h"
+#include "hardware/vreg.h"
 
 #include "pico/bootrom.h"
 #include "pico/stdlib.h"
@@ -294,6 +295,10 @@ namespace picosystem {
     backlight(0);
 
     #ifndef NO_OVERCLOCK
+      // Apply a modest overvolt, default is 1.10v.
+      // this is required for a stable 250MHz on some RP2040s
+      vreg_set_voltage(VREG_VOLTAGE_1_20);
+	    sleep_ms(10);
       // overclock the rp2040 to 250mhz
       set_sys_clock_khz(250000, true);
     #endif


### PR DESCRIPTION
Modest overvolt to fix the few RP2040s that weren't stable at 250MHz/1.1v.