### PR TITLE
make instructions more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ mkdir picosystem
 cd picosystem
 ```
 
-2. Clone this repository
+2. Clone and navigate to this repository
 ```
-git clone git@github.com:pimoroni/picosystem.git
+git clone https://github.com/pimoroni/picosystem.git
+cd picosystem/
 ```
 
 3. Create a build folder and build the examples
 ```
-mkdir build
+mkdir build && cd build
 cmake ..
 make -j8
 ```


### PR DESCRIPTION
the previous instructions could be misinterpreted, so this just flushes out where the build directory should be and where to call `cmake ..`