### PR TITLE
Added (back) the missing playing() function

### DIFF
--- a/libraries/audio.cpp
+++ b/libraries/audio.cpp
@@ -39,6 +39,10 @@ namespace picosystem {
     return (_ms > _duration + _voice.release + _voice.reverb) ? -1 : _ms;
   }
 
+  bool playing() {
+    return position() != -1;
+  }
+
   uint8_t audio_sample(uint32_t ms) {
     // calculate full duration including release and reverb
     uint32_t full_duration = _duration + _voice.release + _voice.reverb;


### PR DESCRIPTION
Looks like jon's tidyup of the audio API (https://github.com/pimoroni/picosystem/pull/63) kept the prototype of `playing()` but lost the actual implementation.

There's an argument that because `position()` now does more of the work that the function is redundant, but we should either have function + prototype, or neither - not just one of them :-)
