### PR TITLE
Buffer fixes

### DIFF
--- a/libraries/picosystem.hpp
+++ b/libraries/picosystem.hpp
@@ -34,9 +34,14 @@ namespace picosystem {
   struct buffer_t {
     int32_t w, h;
     color_t *data;
+    bool alloc;
 
     color_t *p(int32_t x, int32_t y) {
       return data + (x + y * w);
+    }
+
+    ~buffer_t() {
+      if (alloc) delete data;
     }
   };
 

--- a/libraries/utility.cpp
+++ b/libraries/utility.cpp
@@ -60,7 +60,16 @@ namespace picosystem {
     buffer_t *b = new buffer_t();
     b->w = w;
     b->h = h;
-    b->data = data ? (color_t *)data : new color_t[w * h]{};
+    if (data)
+    {
+      b->data = (color_t *)data;
+      b->alloc = false;
+    }
+    else
+    {
+      b->data = new color_t[w * h]{};
+      b->alloc = true;
+    }
     return b;
   }
 

--- a/libraries/utility.cpp
+++ b/libraries/utility.cpp
@@ -60,7 +60,7 @@ namespace picosystem {
     buffer_t *b = new buffer_t();
     b->w = w;
     b->h = h;
-    b->data = data ? (color_t *)data : new color_t[w * h];
+    b->data = data ? (color_t *)data : new color_t[w * h]{};
     return b;
   }
 

--- a/micropython/examples/picosystem/text.py
+++ b/micropython/examples/picosystem/text.py
@@ -10,10 +10,10 @@ douglas = Buffer(32, 45)
 def update(tick):
     global view
 
-    if(pressed(RIGHT)):
+    if pressed(RIGHT):
         view += 1
 
-    if(pressed(LEFT)):
+    if pressed(LEFT):
         view -= 1
 
     view %= view_count


### PR DESCRIPTION
Very small fix to initialise allocated storage when creating a new buffer; otherwise you end up with junk in your buffer, and I've had variable success in clearing it up.

The larger fix is to track when `buffer()` allocates memory when creating a new `buffer_t` object, and to delete it properly on destruction. Obviously only an issue if you create/discard a lot of buffers, but still...