### PR TITLE
Tick once, not twice, per game loop

### DIFF
--- a/libraries/picosystem.cpp
+++ b/libraries/picosystem.cpp
@@ -158,8 +158,6 @@ int main() {
     start_flip = time_us();
     _flip();
 
-    tick++;
-
     stats.tick_us = time_us() - start_tick_us;
 
     // calculate fps and round to nearest value (instead of truncating/floor)


### PR DESCRIPTION
For compatibility with MicroPython this is done between tick and draw, i.e. the loop is draw/tick, draw/tick, etc. rather than tick/draw, tick/draw, etc.