### PR TITLE
`#include <array>` explicitly in examples which need it

### DIFF
--- a/examples/audio/audio.cpp
+++ b/examples/audio/audio.cpp
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <array>
 
 #include "picosystem.hpp"
 

--- a/examples/music/music.cpp
+++ b/examples/music/music.cpp
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <array>
 
 #include "picosystem.hpp"
 

--- a/examples/sprites/sprites.cpp
+++ b/examples/sprites/sprites.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <algorithm>
+#include <array>
 
 #include "picosystem.hpp"
 


### PR DESCRIPTION
Otherwise these examples don't compile with a recent pico-sdk on my system.