### PR TITLE
Included "hardware/clocks.h"

### DIFF
--- a/libraries/hardware.cpp
+++ b/libraries/hardware.cpp
@@ -8,6 +8,7 @@
 #include "hardware/pio.h"
 #include "hardware/irq.h"
 #include "hardware/vreg.h"
+#include "hardware/clocks.h"
 
 #include "pico/bootrom.h"
 #include "pico/stdlib.h"


### PR DESCRIPTION
Pico-SDK-2.0.0 moved set_sys_clock_ functions from "pico/stdlib.h" to "hardware/clocks.h", see https://github.com/raspberrypi/pico-sdk/releases/tag/2.0.0. Just included the new header in "libraries/hardware.cpp".