### PR TITLE
Include hardware/clocks.h for set_sys_clock_khz() when overclocking

### DIFF
--- a/libraries/hardware.cpp
+++ b/libraries/hardware.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "hardware/adc.h"
+#include "hardware/clocks.h"
 #include "hardware/spi.h"
 #include "hardware/dma.h"
 #include "hardware/pwm.h"


### PR DESCRIPTION
I have upgraded to the latest pico sdk. I couldn't compile one of my picosystem programs that uses overclocking. The file libraries/hardware.cpp needs to include hardware/clocks.h for the declaration of set_sys_clock_khz().